### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ MaterialMenuInflater
 
 And that's all there is to it.
 
-#License
+# License
 
 Released under the [Apache 2.0 License](https://github.com/code-mc/material-icon-lib/blob/master/license.md)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
