### PR TITLE
Update ref to license of used project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ And that's all there is to it.
 Released under the [Apache 2.0 License](https://github.com/code-mc/material-icon-lib/blob/master/license.md)
 
 * __MaterialDesignicons__ Released under the [SIL Open Font License 1.1](http://opensource.org/licenses/OFL-1.1)
-* __Google Material Design Icons__ Released under the [Attribution 4.0 International License](https://github.com/google/material-design-icons/blob/master/LICENSE)
+* __Google Material Design Icons__ Released under the [Apache 2.0 License](https://github.com/google/material-design-icons/blob/master/LICENSE)


### PR DESCRIPTION
Google relicensed the Material Design Icons to the Apache 2.0
license for the version 3.0 release in the follow commit:
https://github.com/google/material-design-icons/commit/68e015dbbb6b730b5fe4934e8507cd5a465c8a3d