### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Previews work inside layout files, menu resource files sadly do not support prev
 
 ```groovy
 dependencies {
-    compile 'net.steamcrafted:materialiconlib:1.1.4'
+    implementation 'net.steamcrafted:materialiconlib:1.1.4'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.